### PR TITLE
fix lock file cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+backup/
+lib/

--- a/lazsynaser.pas
+++ b/lazsynaser.pas
@@ -2297,16 +2297,17 @@ begin
     exit;  // done.
   end;
   // Is port owned by orphan? Then it's time for error recovery.
-  //FPC forgot to add getsid.. :-(
   {$IFNDEF FPC}
   if Libc.getsid(ReadLockfile) = -1 then
+  {$ELSE}
+  if FpGetSid(ReadLockfile) = -1 then
+  {$ENDIF}
   begin //  Lockfile was left from former desaster
     DeleteFile(Filename); // error recovery
     CreateLockfile(MyPid);
     result := true;
     exit;
   end;
-  {$ENDIF}
   result := false // Sorry, port is owned by living PID and locked
 end;
 


### PR DESCRIPTION
I have added a call to getsig (missing in FPC) which allows to clean up stale lock files on Linux
I also added IDE temp directories to .gitignore